### PR TITLE
Fix GitHub issues #3 and #4 for branch master.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,10 +110,13 @@ services:
   
   mysqlstaging:
     container_name: ops-mysqlstaging
-    #build: mysqlstaging
-    image: openphacts/identitymappingservice-staging
+    build: mysqlstaging
+    #image: openphacts/identitymappingservice-staging
     links:
       - mysql
+    environment:
+      - MYSQL_HOST=ops-mysql
+      - MYSQL_ROOT_PASSWORD=uCie0ahgah
   #
   # Populate RDF from virtuoso backup download
   virtuosostaging:

--- a/mysqlstaging/staging.sh
+++ b/mysqlstaging/staging.sh
@@ -37,10 +37,9 @@ fi
 
 # To avoid password warnings..
 echo "[client]" > /tmp/my.conf
-echo "host=$MYSQL_PORT_3306_TCP_ADDR" >> /tmp/my.conf
-echo "port=$MYSQL_PORT_3306_TCP_PORT" >> /tmp/my.conf
+echo "host=$MYSQL_HOST" >> /tmp/my.conf
 echo "user=root" >> /tmp/my.conf
-echo "password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD" >> /tmp/my.conf
+echo "password=$MYSQL_ROOT_PASSWORD" >> /tmp/my.conf
 
 # hope that mysql has started
 echo "Waiting for mySQL (up to $MYSQL_SLEEP seconds)"


### PR DESCRIPTION
Link environment variables are superseded in Docker Compose file format version 2.

ref.
https://docs.docker.com/compose/link-env-deprecated/
https://docs.docker.com/engine/userguide/networking/work-with-networks/#limitations-of-docker-network